### PR TITLE
Fixing mistake with Windows CustomApp Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ spicetify config extensions CustomAppOrExtensionName.js
 | **Platform**|**Path**                                                                                    |
 | ------------|--------------------------------------------------------------------------------------------|
 | **macOS**   |~/spicetify_data/Themes <br> **OR**<br>$SPICETIFY_CONFIG/CustomApps                         |
-| **Windows** |%userprofile%\.spicetify\CustomApps\                                                        |
+| **Windows** |%userprofile%\\.spicetify\CustomApps\                                                        |
 | **Linux**   |~/.config/spicetify/CustomApps <br> **OR**<br>$XDG_CONFIG_HOME/.config/spicetify/CustomApps/|
 
 


### PR DESCRIPTION
The old README file was missing a \ in the CustomApp path for Windows, so users who might just copy-paste this path would have faced problems.
Check README preview to see what the change is clearly